### PR TITLE
Enable to provide format read options when uploading a format

### DIFF
--- a/src/Ashampoo.Translation.Systems.Components/src/Components/UploadFormat.razor.cs
+++ b/src/Ashampoo.Translation.Systems.Components/src/Components/UploadFormat.razor.cs
@@ -45,6 +45,15 @@ public partial class UploadFormat : ComponentBase
     /// The start icon of the upload button.
     /// </summary>
     [Parameter] public string StartIcon { get; set; } = Icons.Filled.CloudUpload;
+    
+    /// <summary>
+    /// Callback to configure format options.
+    /// </summary>
+    [Parameter] public FormatOptionsCallback? FormatOptionsCallback { get; set; }
+    /// <summary>
+    /// Options for reading the format.
+    /// </summary>
+    [Parameter] public FormatReadOptions? FormatReadOptions { get; set; }
 
     [Inject] private IFormatService FormatService { get; init; } = default!;
 
@@ -78,7 +87,10 @@ public partial class UploadFormat : ComponentBase
             ms.Position = 0;
 
             // Create the format.
-            format = await FormatService.ReadFromStreamAsync(ms, e.File.Name, FormatOptionsCallback);
+            if(FormatReadOptions is not null) 
+                format = await FormatService.ReadFromStreamAsync(ms, e.File.Name, FormatReadOptions);
+            else
+                format = await FormatService.ReadFromStreamAsync(ms, e.File.Name, FormatOptionsCallback ?? OptionsCallback);
             
             // Get the file name
             fileName = Path.GetFileNameWithoutExtension(e.File.Name);
@@ -101,7 +113,7 @@ public partial class UploadFormat : ComponentBase
     /// </summary>
     /// <param name="options"></param>
     /// <returns>A <see cref="Task"/> representing an asynchronous operation.</returns>
-    private async Task FormatOptionsCallback(FormatOptions options)
+    private async Task OptionsCallback(FormatOptions options)
     {
         await FormatService.ConfigureFormatOptionsAsync(options);
     }

--- a/src/Ashampoo.Translation.Systems.Components/src/Services/FormatService.cs
+++ b/src/Ashampoo.Translation.Systems.Components/src/Services/FormatService.cs
@@ -30,6 +30,7 @@ public class FormatService : IFormatService
         this.formatFactory = formatFactory;
     }
 
+
     /// <inheritdoc />
     public IFormat ConvertTo(IFormat format, string convertFormatId,
         FormatOptionsCallback? formatOptionsCallback = null, AssignOptions? options = null)
@@ -56,6 +57,19 @@ public class FormatService : IFormatService
         return formatReadOptions.IsCancelled ? null : format;
     }
 
+    /// <inheritdoc />
+    public async Task<IFormat?> ReadFromStreamAsync(Stream stream, string fileName, FormatReadOptions readOptions)
+    {
+        var format = formatFactory.TryCreateFormatByFileName(fileName) ??
+                     throw new InvalidOperationException("File type not supported.");
+        
+        await format.ReadAsync(stream, readOptions);
+        
+        return readOptions.IsCancelled ? null : format;
+        
+        
+    }
+    
     /// <inheritdoc />
     public async Task ConfigureFormatOptionsAsync(FormatOptions options, string title = "Configure format options")
     {

--- a/src/Ashampoo.Translation.Systems.Components/src/Services/IFormatService.cs
+++ b/src/Ashampoo.Translation.Systems.Components/src/Services/IFormatService.cs
@@ -8,7 +8,7 @@ namespace Ashampoo.Translation.Systems.Components.Services;
 public interface IFormatService
 {
     /// <summary>
-    /// Create a new instance of IFormat from the given stream.
+    /// Create a new instance of <see cref="IFormat"/> from the given stream.
     /// </summary>
     /// <param name="stream">
     /// The stream to read the format from.
@@ -20,7 +20,30 @@ public interface IFormatService
     /// The options to use when creating the format.
     /// </param>
     /// <returns> A new instance of IFormat</returns>
+    /// /// <exception cref="InvalidOperationException">
+    /// Thrown if the file type is not supported.
+    /// </exception>
     Task<IFormat?> ReadFromStreamAsync(Stream stream, string fileName, FormatOptionsCallback? options = null);
+    
+    /// <summary>
+    /// Create a new instance of <see cref="IFormat"/> from the given stream.
+    /// </summary>
+    /// <param name="stream">
+    /// The stream to read the format from.
+    /// </param>
+    /// <param name="fileName">
+    /// The name of the file the stream is from.
+    /// </param>
+    /// <param name="readOptions">
+    /// The options to use when reading the format.
+    /// </param>
+    /// <returns>
+    /// A new instance of IFormat, or null if the format could not be read.
+    /// </returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown if the file type is not supported.
+    /// </exception>
+    Task<IFormat?> ReadFromStreamAsync(Stream stream, string fileName, FormatReadOptions readOptions);
 
     /// <summary>
     /// Convert the given instance of IFormat into the format specified by id.


### PR DESCRIPTION
You can now provide format read options, when uploading a format via the UploadFormat blazor component. 