### PR TITLE
Try parse languages with script tag

### DIFF
--- a/src/Ashampoo.Translation.Systems.Components/src/Ashampoo.Translation.Systems.Components.csproj
+++ b/src/Ashampoo.Translation.Systems.Components/src/Ashampoo.Translation.Systems.Components.csproj
@@ -43,9 +43,5 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
     </ItemGroup>
-
-    <ItemGroup>
-      <Folder Include="src" />
-    </ItemGroup>
     
 </Project>

--- a/src/Ashampoo.Translation.Systems.Formats.Abstractions/tests/LanguageParserTests.cs
+++ b/src/Ashampoo.Translation.Systems.Formats.Abstractions/tests/LanguageParserTests.cs
@@ -1,0 +1,34 @@
+﻿using Xunit;
+
+namespace Ashampoo.Translation.Systems.Formats.Abstractions.Tests;
+
+public class LanguageParserTests
+{
+    [Fact]
+    public void ParseLanguageCountryTest()
+    {
+        const string filePath = "Snap14-en-us.json";
+        var language = LanguageParser.TryParseLanguageId(filePath);
+        Assert.Equal("en-US", language);
+    }
+
+    [Fact]
+    public void ParseLanguageScriptTagCountryTest()
+    {
+        const string filePath = "Snap14-zh-Hant-TW.json";
+        var language = LanguageParser.TryParseLanguageId(filePath);
+        Assert.Equal("zh-Hant-TW", language);
+    }
+    
+
+    [Fact]
+    public void ValidLanguageCodeTest()
+    {
+        const string languageCodeChinese = "zh-Hant-TW";
+        const string languageCodeEnglish = "en-US";
+        var chineseIsValid = LanguageParser.IsValidLanguageCode(languageCodeChinese);
+        var englishIsValid = LanguageParser.IsValidLanguageCode(languageCodeEnglish);
+        Assert.True(chineseIsValid);
+        Assert.True(englishIsValid);
+    }
+}


### PR DESCRIPTION
Updated the language parser, to try and parse languages in the format languagecode2-scripttag-country/regioncode2.
Also included tests for the language parser.